### PR TITLE
Nifi instance identification: hostname -> instance IP

### DIFF
--- a/start_nifi.sh
+++ b/start_nifi.sh
@@ -2,9 +2,11 @@
 
 set -e
 
+INSTANCE_IP=`hostname -i`
+
 do_site2site_configure() {
   if [ -z "$S2S_PORT" ]; then S2S_PORT=2881; fi
-  sed -i "s/nifi\.remote\.input\.host=.*/nifi.remote.input.host=${HOSTNAME}/g" ${NIFI_HOME}/conf/nifi.properties
+  sed -i "s/nifi\.remote\.input\.host=.*/nifi.remote.input.host=${INSTANCE_IP}/g" ${NIFI_HOME}/conf/nifi.properties
   sed -i "s/nifi\.remote\.input\.socket\.port=.*/nifi.remote.input.socket.port=${S2S_PORT}/g" ${NIFI_HOME}/conf/nifi.properties
   sed -i "s/nifi\.remote\.input\.secure=true/nifi.remote.input.secure=false/g" ${NIFI_HOME}/conf/nifi.properties
 }
@@ -16,10 +18,10 @@ do_cluster_node_configure() {
   sed -i "s/clientPort=.*/clientPort=${ZK_CLIENT_PORT}/g" ${NIFI_HOME}/conf/zookeeper.properties
   ZK_CONNECT_STRING=$(echo $ZK_NODES | sed -e "s/,/:${ZK_CLIENT_PORT},/g" -e "s/$/:${ZK_CLIENT_PORT}/g")
 
-  sed -i "s/nifi\.web\.http\.host=.*/nifi.web.http.host=${HOSTNAME}/g" ${NIFI_HOME}/conf/nifi.properties
+  sed -i "s/nifi\.web\.http\.host=.*/nifi.web.http.host=${INSTANCE_IP}/g" ${NIFI_HOME}/conf/nifi.properties
   sed -i "s/nifi\.cluster\.protocol\.is\.secure=true/nifi.cluster.protocol.is.secure=false/g" ${NIFI_HOME}/conf/nifi.properties
   sed -i "s/nifi\.cluster\.is\.node=false/nifi.cluster.is.node=true/g" ${NIFI_HOME}/conf/nifi.properties
-  sed -i "s/nifi\.cluster\.node\.address=.*/nifi.cluster.node.address=${HOSTNAME}/g" ${NIFI_HOME}/conf/nifi.properties
+  sed -i "s/nifi\.cluster\.node\.address=.*/nifi.cluster.node.address=${INSTANCE_IP}/g" ${NIFI_HOME}/conf/nifi.properties
 
   if [ -z "$NODE_PROTOCOL_PORT" ]; then NODE_PROTOCOL_PORT=2882; fi
   sed -i "s/nifi\.cluster\.node\.protocol\.port=.*/nifi.cluster.node.protocol.port=${NODE_PROTOCOL_PORT}/g" ${NIFI_HOME}/conf/nifi.properties
@@ -27,7 +29,7 @@ do_cluster_node_configure() {
 
   if [ -z "$ZK_ROOT_NODE" ]; then sed -i "s/nifi\.zookeeper\.root\.node=.*/nifi.zookeeper.root.node=$ZK_ROOT_NODE/g" ${NIFI_HOME}/conf/nifi.properties; fi
   sed -i "s/<property name=\"Connect String\">.*</<property name=\"Connect String\">$ZK_CONNECT_STRING</g" ${NIFI_HOME}/conf/state-management.xml
- 
+
   if [ ! -z "$ZK_MYID" ]; then
     sed -i "s/nifi\.state\.management\.embedded\.zookeeper\.start=false/nifi.state.management.embedded.zookeeper.start=true/g" ${NIFI_HOME}/conf/nifi.properties
     mkdir -p ${NIFI_HOME}/state/zookeeper


### PR DESCRIPTION
The current docker image uses the hostname (which in case of docker is the container id) to identify/register the nifi instance. However, these container ids can't get resolved in a virtual network running on DC/OS. Therefore the NiFi instances can't send out their heartbeat to the cluster coordinator.
This PR uses the container IP instead of the hostname to resolve this issue.

@brunodebus @Krieke 